### PR TITLE
More optimizations

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         android:roundIcon="@mipmap/mirror_lake_logo"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.Wallpaper.NoTitleBar"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:hardwareAccelerated="true" >
         <activity
             android:name=".SetWallpaperActivity"
             android:exported="true">

--- a/app/src/main/java/rak/pixellwp/cycling/PaletteDrawer.kt
+++ b/app/src/main/java/rak/pixellwp/cycling/PaletteDrawer.kt
@@ -72,7 +72,13 @@ class PaletteDrawer(private val engine: CyclingWallpaperService.CyclingWallpaper
     private fun drawFrame(surfaceHolder: SurfaceHolder, imageSrc: Rect, screenDimensions: Rect) {
         if (visible && !surfaceHolder.isCreating) {
             try {
-                surfaceHolder.lockCanvas()?.let { canvas ->
+                val canvas = if (android.os.Build.VERSION.SDK_INT >= 26) {
+                    surfaceHolder.lockHardwareCanvas() //It is less CPU intensive to lock an hardware canvas
+                } else {
+                    surfaceHolder.lockCanvas()
+                }
+
+                if(canvas != null) {
                     canvas.drawBitmap(image.getBitmap(), imageSrc, screenDimensions, null)
                     surfaceHolder.unlockCanvasAndPost(canvas)
                 }

--- a/app/src/main/java/rak/pixellwp/cycling/PaletteDrawer.kt
+++ b/app/src/main/java/rak/pixellwp/cycling/PaletteDrawer.kt
@@ -64,7 +64,7 @@ class PaletteDrawer(private val engine: CyclingWallpaperService.CyclingWallpaper
     }
 
     private fun advanceAndDraw() {
-        val timePassed = floor((Date().time - startTime).toDouble()).toInt()
+        val timePassed = (Date().time - startTime).toInt()
         image.advance(timePassed)
         drawFrame(engine.surfaceHolder, engine.getOffsetImage(), engine.screenDimensions)
     }

--- a/app/src/main/java/rak/pixellwp/cycling/models/ColorCyclingImage.kt
+++ b/app/src/main/java/rak/pixellwp/cycling/models/ColorCyclingImage.kt
@@ -9,7 +9,7 @@ class ColorCyclingImage(img: ImageJson) : PaletteImage {
     private var palette = Palette(colors = img.getParsedColors(), cycles = img.cycles)
     private val pixels = img.pixels.toList()
     private val rawPixels = IntArray(width*height)
-    private var optimizedPixels = optimizePixels(pixels)
+    private val optimizedPixels = optimizePixels(pixels)
     private var drawUnOptimized = true
     private val bitmap: Bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
 
@@ -44,8 +44,8 @@ class ColorCyclingImage(img: ImageJson) : PaletteImage {
         return palette
     }
 
-    private fun optimizePixels(pixels: List<Int>) : List<Triple<Int,Int,Int>> {
-        val optPixels = mutableListOf<Triple<Int,Int,Int>>()
+    private fun optimizePixels(pixels: List<Int>) : List<Pair<Int,Int>> {
+        val optPixels = mutableListOf<Pair<Int,Int>>()
         val optColors = BooleanArray(pixels.size) { false }.toMutableList()
 
         palette.cycles
@@ -58,12 +58,12 @@ class ColorCyclingImage(img: ImageJson) : PaletteImage {
             for (x in 0 until width) {
                 //If this pixel references an animated color
                 if (optColors[pixels[j]]){
-                    optPixels.add(Triple(x, y, j))
+                    optPixels.add(Pair(y*width+x, pixels[j]))
                 }
                 j++
             }
         }
-        return optPixels
+        return optPixels.toList()
     }
 
     private fun draw() {
@@ -82,8 +82,8 @@ class ColorCyclingImage(img: ImageJson) : PaletteImage {
     }
 
     private fun drawOptimizedImage(){
-        for ((x, y, j) in optimizedPixels){
-            rawPixels[(y*width)+x]=palette.colors[pixels[j]]
+        for ((x, j) in optimizedPixels){
+            rawPixels[x]=palette.colors[j]
         }
     }
 }

--- a/app/src/main/java/rak/pixellwp/cycling/models/Cycle.kt
+++ b/app/src/main/java/rak/pixellwp/cycling/models/Cycle.kt
@@ -3,16 +3,17 @@ package rak.pixellwp.cycling.models
 import kotlin.math.floor
 import kotlin.math.sin
 
-const val precision: Double = 100.0
+const val precision: Float = 100.0F
 const val precisionInt: Int = 100
+const val PI: Float = 3.141592653589793F
 
 data class Cycle(val rate: Int, private val reverse: Int, val low: Int, val high: Int) {
-    private val cycleSpeed: Double = 280.0
+    private val cycleSpeed: Float = 280.0F
 
     private val size = high - low + 1
     private val adjustedRate: Float = (rate / cycleSpeed).toFloat()
 
-    private fun dFloatMod(a: Float, b: Int) : Double {
+    private fun dFloatMod(a: Float, b: Int) : Float {
         return (floor((a* precision)) % floor((b* precision))) / precision
     }
 
@@ -27,8 +28,8 @@ data class Cycle(val rate: Int, private val reverse: Int, val low: Int, val high
         }
     }
 
-    fun getCycleAmount(timePassed: Int) : Double{
-        var cycleAmount = 0.0
+    fun getCycleAmount(timePassed: Int) : Float{
+        var cycleAmount = 0.0F
         if (reverse < 3){
             //standard cycle
             cycleAmount = dFloatMod(timePassed / (1000/adjustedRate), size)
@@ -41,7 +42,7 @@ data class Cycle(val rate: Int, private val reverse: Int, val low: Int, val high
         } else if (reverse < 6){
             //sine wave
             cycleAmount = dFloatMod(timePassed / (1000/adjustedRate), size)
-            cycleAmount = (sin(cycleAmount * Math.PI * 2/size) + 1)
+            cycleAmount = (sin(cycleAmount * PI * 2/size) + 1)
             if (reverse == 4){
                 cycleAmount *= size/4
             } else if (reverse == 5){

--- a/app/src/main/java/rak/pixellwp/cycling/models/Palette.kt
+++ b/app/src/main/java/rak/pixellwp/cycling/models/Palette.kt
@@ -34,7 +34,7 @@ class Palette(val id: String = "", colors: List<Int>, val cycles: List<Cycle>) {
                 }
     }
 
-    fun shiftColors(colors: MutableList<Int>, cycle: Cycle, amount: Double) {
+    fun shiftColors(colors: MutableList<Int>, cycle: Cycle, amount: Float) {
         val intAmount = amount.toInt()
         for (i in 0 until intAmount) {
             val temp = colors[cycle.high]
@@ -46,7 +46,7 @@ class Palette(val id: String = "", colors: List<Int>, val cycles: List<Cycle>) {
     }
 
     // BlendShift Technology conceived, designed and coded by Joseph Huckaby
-    private fun blendShiftColors(colors: MutableList<Int>, cycle: Cycle, amount: Double) {
+    private fun blendShiftColors(colors: MutableList<Int>, cycle: Cycle, amount: Float) {
         shiftColors(colors, cycle, amount)
 
         val remainder = floor((amount - floor(amount)) * precision).toInt()

--- a/app/src/main/java/rak/pixellwp/cycling/models/Timeline.kt
+++ b/app/src/main/java/rak/pixellwp/cycling/models/Timeline.kt
@@ -2,18 +2,19 @@ package rak.pixellwp.cycling.models
 
 import android.util.Log
 import rak.pixellwp.cycling.TimelineBlender
+import java.util.*
 
 class Timeline(entries: Map<String, String>, palettes: List<Palette>) {
     private val logTag = "Timeline"
-    private val timeToPalette: Map<Int, Palette> = parseEntries(entries, palettes)
+    private val timeToPalette: TreeMap<Int, Palette> = parseEntries(entries, palettes)
     private val blender = TimelineBlender(timeToPalette.entries.first())
 
     init {
         Log.d(logTag, "Initing timeline image with palettes at " + timeToPalette.keys.sorted().map { time -> "$time" }.toList())
     }
 
-    private fun parseEntries(entries: Map<String, String>, palettes: List<Palette>): Map<Int, Palette> {
-        val map = HashMap<Int, Palette>()
+    private fun parseEntries(entries: Map<String, String>, palettes: List<Palette>): TreeMap<Int, Palette> {
+        val map = TreeMap<Int, Palette>()
         entries.forEach{ entry -> map[Integer.parseInt(entry.key)] = palettes.first { it.id == entry.value } }
         return map
     }
@@ -23,15 +24,11 @@ class Timeline(entries: Map<String, String>, palettes: List<Palette>) {
     }
 
     fun getPreviousPalette(currentTime: Int): Map.Entry<Int, Palette> {
-        return timeToPalette.filter { it.key < currentTime}
-                .entries.sortedBy { it.key }.lastOrNull()
-                ?: timeToPalette.entries.sortedBy { it.key }.last()
+        return timeToPalette.lowerEntry(currentTime)?:timeToPalette.lastEntry()!!
     }
 
     fun getNextPalette(currentTime: Int): Map.Entry<Int, Palette>  {
-        return timeToPalette.filter { it.key > currentTime}
-                .entries.sortedBy { it.key }.firstOrNull()
-                ?: timeToPalette.entries.sortedBy { it.key }.first()
+        return timeToPalette.higherEntry(currentTime)?:timeToPalette.firstEntry()!!
     }
 
 }

--- a/app/src/main/java/rak/pixellwp/cycling/wallpaperService/CyclingWallpaperService.kt
+++ b/app/src/main/java/rak/pixellwp/cycling/wallpaperService/CyclingWallpaperService.kt
@@ -61,7 +61,6 @@ class CyclingWallpaperService : WallpaperService() {
         init {
             changeImage(loadInitialImage())
             downloadFirstTimeImage()
-            drawRunner.startDrawing()
         }
 
         override fun imageLoadComplete(image: ImageInfo) {


### PR DESCRIPTION
Hey again !
So I did some more diggings, and ended up with those optimizations.
I separated them by commit, so feel free to check them out and discuss here if you have any doubts.
Basically :

1. From what I saw, surfaceHolder.lockCanvas() is pretty slow. surfaceHolder.lockHardwareCanvas() is way quicker, but sadly only on api 26+ :( As I was the one modifying the min API to 25, I would understand if you'd rather not take the burden to maintain the app for ~5% of users (me included). However, I only profiled it on an emulator atm. Tell me what you think ! 
2.  Optimized a bit more the renderer, by storing the offset (y*width+x) and the value (pixel[j]) instead of them separatly which make the frame drawer do less each iteration
3. I don't think we need double precision here, and as pretty much all arm CPU are still 32bits I think it make sense to only use floats
4. I optimized the palette sorting by using a TreeMap, which combines an OrderedMap and a NavigableMap. So you don't have to sort the palettes on each frames now !
5. I'm pretty sure that's a bug : I saw that 2 drawThread were spawed, one by the init and one by the surfaceCreation. By removing one, no problem seems to ensue but i'd like to have your opinion on that !

Tell me what you think :)