### PR TITLE
Optimized allocations by using an IntArray instead of a mutableList

### DIFF
--- a/app/src/main/java/rak/pixellwp/cycling/models/Cycle.kt
+++ b/app/src/main/java/rak/pixellwp/cycling/models/Cycle.kt
@@ -17,7 +17,7 @@ data class Cycle(val rate: Int, private val reverse: Int, val low: Int, val high
         return (floor((a* precision)) % floor((b* precision))) / precision
     }
 
-    fun reverseColorsIfNecessary(colors: MutableList<Int>){
+    fun reverseColorsIfNecessary(colors: IntArray){
         if (reverse == 2){
             for (i in 0 until size/2){
                 val lowValue = colors[low+i]


### PR DESCRIPTION
Hey ! 
I forgot to send you this one. 
It greatly reduce memory pressure and garbage collection, as we don't create new lists on each draw.
You don't want a mutable list, as the list itself won't change after being created. However, each value in the list/array is still mutable. Like that, we only allocate the Int once and we mutate them when needed.
Bonus, the app use less memory overall !