### PR TITLE
Fix the jumpiness on each loop, as the last color wasn't correctly blend

### DIFF
--- a/app/src/main/java/rak/pixellwp/cycling/models/Palette.kt
+++ b/app/src/main/java/rak/pixellwp/cycling/models/Palette.kt
@@ -54,7 +54,7 @@ class Palette(val id: String = "", colors: List<Int>, val cycles: List<Cycle>) {
         for (j in (cycle.high - 1) downTo cycle.low) {
             colors[j + 1] = fadeColors(colors[j+1], colors[j], remainder)
         }
-        colors[cycle.low] = temp
+        colors[cycle.low] = fadeColors(colors[cycle.low], temp, remainder)
     }
 
     private fun fadeColors(sourceColor: Int, destColor: Int, frame: Int): Int {


### PR DESCRIPTION
Hey ! It's me again :)
I noticed a 'jumpiness' on each loop a while ago, and I finally had time to check.
I compared your version against the original in javascript, and I saw that you forgot to blend the last color with the first one. So here is the fix !
The bug was particularly visible on winter forest with snow, if you wants to check yourself.