### PR TITLE
Fix timeline image with remap without collection #15

### DIFF
--- a/app/src/main/java/rak/pixellwp/cycling/jsonModels/ImageCollection.kt
+++ b/app/src/main/java/rak/pixellwp/cycling/jsonModels/ImageCollection.kt
@@ -13,7 +13,8 @@ import java.util.*
 @JsonIgnoreProperties(ignoreUnknown = true)
 class ImageCollection(val name: String, val images: List<ImageInfo>) {
     @JsonCreator
-    constructor(name: String, id: String = "", month: String = "", script: String = "", weather: WeatherType = WeatherType.CLEAR, images: List<ImageInfo>?) : this(name, images ?: listOf(ImageInfo(name, id, month = month, script = script, weather = weather)))
+    constructor(name: String, id: String = "", month: String = "", script: String = "", weather: WeatherType = WeatherType.CLEAR, remap: Map<Int, IntArray> = emptyMap(), images: List<ImageInfo>?)
+            : this(name, images ?: listOf(ImageInfo(name, id, month = month, script = script, weather = weather, remap =  remap)))
 
     override fun toString(): String {
         return "Collection: $name" + images.map { it.toString() }


### PR DESCRIPTION
Hey !
So, funny story. I kind of forgot that I wanted to work a bit more on this before next release, and then a year passed ... Anyway, I have a new phone and I'd like to have the latest release from Fdroid instead of building myself. And I saw issue #15.
So, here is the fix. The problem was that the attribute "remap" was only set for images part of a collection and not for images alone. Easy fix :)