### PR TITLE
fix: added compression while downloading.

### DIFF
--- a/app/src/main/java/rak/pixellwp/cycling/jsonLoading/JsonDownloader.kt
+++ b/app/src/main/java/rak/pixellwp/cycling/jsonLoading/JsonDownloader.kt
@@ -1,12 +1,12 @@
 package rak.pixellwp.cycling.jsonLoading
 
 import android.util.Log
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
+
 import rak.pixellwp.cycling.jsonModels.ImageInfo
+
 import java.net.URL
-import kotlin.concurrent.thread
+import java.util.zip.GZIPInputStream
+
 
 
 class JsonDownloader(
@@ -24,7 +24,9 @@ class JsonDownloader(
 
     private fun downloadImage(): String? {
         try {
-            val inputStream = URL(getFullUrl(image)).openStream()
+            val urlConnection = URL(getFullUrl(image)).openConnection()
+            urlConnection.setRequestProperty("Accept-Encoding", "gzip")
+            val inputStream = GZIPInputStream(urlConnection.inputStream)
 
             val s = java.util.Scanner(inputStream).useDelimiter("\\A")
             val json = if (s.hasNext()) s.next() else ""


### PR DESCRIPTION
OK I remembered what I wanted to add.
By default, the URL object download only with plaintext. We can easily add compression, and the result is impressive :
* Without compression : ~60MB downloaded
* With compression : ~3MB downloaded ? (I'm not sure how you can measure precisely tbh)